### PR TITLE
Fixes issue #6 RG and TwoFG work for all variants

### DIFF
--- a/onRobot/onRobot/gripper.py
+++ b/onRobot/onRobot/gripper.py
@@ -106,7 +106,7 @@ class VG10:
         curl.close()
 
 
-class RG2:
+class RG:
     def __init__(self, robot_ip, rg_id):
         self.rg_id = rg_id
         self.robot_ip = robot_ip
@@ -213,7 +213,7 @@ class RG2:
         curl.close()
 
 
-class TwoFG7():
+class TwoFG():
     def __init__(self, robot_ip: str, id: int):
         self.robot_ip = robot_ip
         self.id = id


### PR DESCRIPTION
RG2 and TwoFG7 classes renamed to RG and TwoFG as per issue 6:
https://github.com/RyanPaulMcKenna/onRobot/issues/6

